### PR TITLE
Set BAT_INDEX as `uint16` in example code

### DIFF
--- a/rscp/request.go
+++ b/rscp/request.go
@@ -31,7 +31,7 @@ func validateRequests(messages []Message) error {
 //
 //	CreateRequest(INFO_REQ_UTC_TIME)
 //	CreateRequest(EMS_REQ_SET_ERROR_BUZZER_ENABLED, true)
-//	CreateRequest(BAT_REQ_DATA, BAT_INDEX, 0, BAT_REQ_DEVICE_STATE, BAT_REQ_RSOC, BAT_REQ_STATUS_CODE)
+//	CreateRequest(BAT_REQ_DATA, BAT_INDEX, uint16(0), BAT_REQ_DEVICE_STATE, BAT_REQ_RSOC, BAT_REQ_STATUS_CODE)
 func CreateRequest(values ...interface{}) (msg *Message, err error) {
 	if msg, err = readRequestSlice(values); err != nil {
 		return nil, err
@@ -45,7 +45,7 @@ func CreateRequest(values ...interface{}) (msg *Message, err error) {
 //
 //	CreateRequests([]interface{}{INFO_REQ_UTC_TIME})
 //	CreateRequests([]interface{}{EMS_REQ_SET_ERROR_BUZZER_ENABLED, true})
-//	CreateRequests([]interface{}{BAT_REQ_DATA, BAT_INDEX, 0, BAT_REQ_DEVICE_STATE, BAT_REQ_RSOC, BAT_REQ_STATUS_CODE})
+//	CreateRequests([]interface{}{BAT_REQ_DATA, BAT_INDEX, uint16(0), BAT_REQ_DEVICE_STATE, BAT_REQ_RSOC, BAT_REQ_STATUS_CODE})
 func CreateRequests(values ...[]interface{}) ([]Message, error) {
 	if len(values) == 0 {
 		return nil, ErrNoArguments


### PR DESCRIPTION
This just cost me around 30 minutes because I couldn't figure out why the example code wasn't working, I always got this:
```
ERRO[0000] message at index 0: expected *uint16 got int : value does not match data type
```
And then even when I tried to pass a `*uint16` as requested, I got

```
ERRO[0000] message at index 0: expected *uint16 got *uint16 : value does not match data type
```

so maybe the error message could use some improvements as well.

But most important is to set the value as uint16 and the example will work.