### PR TITLE
Close broken connections

### DIFF
--- a/rscp/client.go
+++ b/rscp/client.go
@@ -88,7 +88,7 @@ func (c *Client) receive() ([]Message, error) {
 		var err error
 		if i, err = c.conn.Read(data); err != nil {
 			_ = c.Disconnect()
-			return nil, fmt.Errorf("error during receive response: %w", err)
+			return nil, err
 		} else if i == 0 {
 			return nil, ErrRscpInvalidFrameLength
 		}


### PR DESCRIPTION
Close broken connections so they will be reopened on next operation.

Depends on https://github.com/spali/go-rscp/pull/68. Refs https://github.com/evcc-io/evcc/issues/17446#issuecomment-2509683073.

Note: I've removed the receive error annotation since send doesn't add one either.